### PR TITLE
Make cursor placement on <C-X><Space> reliable.

### DIFF
--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -53,7 +53,7 @@ function! s:Init()
   imap     <buffer> <C-X>H <SID>HtmlComplete
   inoremap <silent> <buffer> <C-X>$ <C-R>=<SID>javascriptIncludeTag()<CR>
   inoremap <silent> <buffer> <C-X>@ <C-R>=<SID>stylesheetTag()<CR>
-  inoremap <silent> <buffer> <C-X><Space> <Esc>ciW<Lt><C-R>"<C-R>=<SID>tagextras()<CR>></<C-R>"><Esc>b2hi
+  inoremap <silent> <buffer> <C-X><Space> <Esc>ciW<Lt><C-R>"<C-R>=<SID>tagextras()<CR>></<C-R>"><Esc>F<i
   inoremap <silent> <buffer> <C-X><CR> <Esc>ciW<Lt><C-R>"<C-R>=<SID>tagextras()<CR>><CR></<C-R>"><Esc>O
   if exists("&omnifunc")
     inoremap <silent> <buffer> <C-X>/ <Lt>/<C-R>=<SID>htmlEn()<CR><C-X><C-O><C-R>=<SID>htmlDis()<CR><C-F>


### PR DESCRIPTION
Whereas the cursor was being returned mid-tag for multi-word tags:

`foo-bar| ... <foo-bar></fo|o-bar>`

it's now where it belongs:

`foo-bar| ... <foo-bar>|</foo-bar>`
