### PR TITLE
.gitignore helptags generated doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Important to have this when using vim-ragtag via pathogen as a git submodule

Thanks
