### PR TITLE
Add eelixir filetype to support html.eex files

### DIFF
--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -25,9 +25,9 @@ augroup ragtag
   autocmd!
   autocmd BufReadPost * if ! did_filetype() && getline(1)." ".getline(2).
         \ " ".getline(3) =~? '<\%(!DOCTYPE \)\=html\>' | setf html | endif
-  autocmd FileType *html*,wml,jsp,gsp,mustache,smarty call s:Init()
-  autocmd FileType php,asp*,cf,mason,eruby,liquid,jst call s:Init()
-  autocmd FileType xml,xslt,xsd,docbk                 call s:Init()
+  autocmd FileType *html*,wml,jsp,gsp,mustache,smarty         call s:Init()
+  autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir call s:Init()
+  autocmd FileType xml,xslt,xsd,docbk                         call s:Init()
   autocmd InsertLeave * call s:Leave()
   autocmd CursorHold * if exists("b:loaded_ragtag") | call s:Leave() | endif
 augroup END


### PR DESCRIPTION
Frameworks like Phoenix use the .eex file type (`something.html.eex`) and I noticed RagTag wasn't working on any files other than `application.html.eex`.

 For example. a file in `templates/page/index.html.eex` refused to work. `b:ragtag_loaded` wasn't declared or available.  However, `templates/layouts/application.html.eex` works fine and I can use `:verbose imap` to prove that Ragtag did load its commands.

Adding an explicit type of `eelixir` to RagTag fixes the problem for all my files, although there may be a better fix that I don't understand.