### PR TITLE
Use ftdetect mechanism with `setf html`

### DIFF
--- a/ftdetect/ragtag.vim
+++ b/ftdetect/ragtag.vim
@@ -1,0 +1,2 @@
+autocmd BufReadPost * if ! did_filetype() && getline(1)." ".getline(2).
+      \ " ".getline(3) =~? '<\%(!DOCTYPE \)\=html\>' | setf html | endif

--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -23,8 +23,6 @@ endif
 
 augroup ragtag
   autocmd!
-  autocmd BufReadPost * if ! did_filetype() && getline(1)." ".getline(2).
-        \ " ".getline(3) =~? '<\%(!DOCTYPE \)\=html\>' | setf html | endif
   autocmd FileType *html*,wml,jsp,gsp,mustache,smarty         call s:Init()
   autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir call s:Init()
   autocmd FileType xml,xslt,xsd,docbk                         call s:Init()


### PR DESCRIPTION
In commit 12e3799 an aggressive method of detecting "html" filetypes was
added.

But it is too aggressive, and causes problems with (re)loading a file like
the following, which got detected as "htmldjango" by Vim's
`filetype.vim` process initially:

    {% load staticfiles %}

    <!DOCTYPE html>
    <html …>

While `BufRead,BufNewFile` is used typically, this patch keeps using
`BufReadPost`, which appears to be used to target netrw explicitly?!