### PR TITLE
Add support for Typescript

### DIFF
--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -29,6 +29,7 @@ augroup ragtag
   autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir call s:Init()
   autocmd FileType xml,xslt,xsd,docbk                         call s:Init()
   autocmd FileType javascript.jsx,jsx,handlebars              call s:Init()
+  autocmd FileType typescript.tsx                             call s:Init()
   autocmd InsertLeave * call s:Leave()
   autocmd CursorHold * if exists("b:loaded_ragtag") | call s:Leave() | endif
 augroup END


### PR DESCRIPTION
With this you can also use `vim-ragtag` in `.tsx`-files. 👍 

I'm not sure if I should include `,tsx` to make it symmetric with `jsx`. I've left it out for now.