### PR TITLE
Add new javascriptreact and typescriptreact filetypes

### DIFF
--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -30,6 +30,8 @@ augroup ragtag
   autocmd FileType xml,xslt,xsd,docbk                         call s:Init()
   autocmd FileType javascript.jsx,jsx,handlebars              call s:Init()
   autocmd FileType typescript.tsx                             call s:Init()
+  autocmd FileType javascript.jsx,jsx,javascriptreact,handlebars  call s:Init()
+  autocmd FileType typescript.tsx,tsx,typescriptreact             call s:Init()
   autocmd InsertLeave * call s:Leave()
   autocmd CursorHold * if exists("b:loaded_ragtag") | call s:Leave() | endif
 augroup END

--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -25,11 +25,9 @@ augroup ragtag
   autocmd!
   autocmd BufReadPost * if ! did_filetype() && getline(1)." ".getline(2).
         \ " ".getline(3) =~? '<\%(!DOCTYPE \)\=html\>' | setf html | endif
-  autocmd FileType *html*,wml,jsp,gsp,mustache,smarty         call s:Init()
-  autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir call s:Init()
-  autocmd FileType xml,xslt,xsd,docbk                         call s:Init()
-  autocmd FileType javascript.jsx,jsx,handlebars              call s:Init()
-  autocmd FileType typescript.tsx                             call s:Init()
+  autocmd FileType *html*,wml,jsp,gsp,mustache,smarty             call s:Init()
+  autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir     call s:Init()
+  autocmd FileType xml,xslt,xsd,docbk                             call s:Init()
   autocmd FileType javascript.jsx,jsx,javascriptreact,handlebars  call s:Init()
   autocmd FileType typescript.tsx,tsx,typescriptreact             call s:Init()
   autocmd InsertLeave * call s:Leave()


### PR DESCRIPTION
for reference:
https://github.com/vim/vim/issues/4830

basically, new versions of vim now read `.jsx` and `.tsx` extensions as `{javascript,typescript}react` (for LSP reasons) which causes to this plugin to not initialize. Many plugins (like ragtag) are not working properly because of it, the change seems like it might not be permanent. but who knows...