### PR TITLE
Include HEEx templates as supported filetype

### DIFF
--- a/plugin/ragtag.vim
+++ b/plugin/ragtag.vim
@@ -25,12 +25,12 @@ augroup ragtag
   autocmd!
   autocmd BufReadPost * if ! did_filetype() && getline(1)." ".getline(2).
         \ " ".getline(3) =~? '<\%(!DOCTYPE \)\=html\>' | setf html | endif
-  autocmd FileType *html*,wml,jsp,gsp,mustache,smarty             call s:Init()
-  autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir     call s:Init()
-  autocmd FileType xml,xslt,xsd,docbk                             call s:Init()
-  autocmd FileType vue                                            call s:Init()
-  autocmd FileType javascript.jsx,jsx,javascriptreact,handlebars  call s:Init()
-  autocmd FileType typescript.tsx,tsx,typescriptreact             call s:Init()
+  autocmd FileType *html*,wml,jsp,gsp,mustache,smarty              call s:Init()
+  autocmd FileType php,asp*,cf,mason,eruby,liquid,jst,eelixir,heex call s:Init()
+  autocmd FileType xml,xslt,xsd,docbk                              call s:Init()
+  autocmd FileType vue                                             call s:Init()
+  autocmd FileType javascript.jsx,jsx,javascriptreact,handlebars   call s:Init()
+  autocmd FileType typescript.tsx,tsx,typescriptreact              call s:Init()
   autocmd InsertLeave * call s:Leave()
   autocmd CursorHold * if exists("b:loaded_ragtag") | call s:Leave() | endif
 augroup END


### PR DESCRIPTION
Includes support for [HEEx templates](https://hexdocs.pm/phoenix_live_view/assigns-eex.html) which are part of the [Phoenix framework](https://phoenixframework.org) view layer.